### PR TITLE
[STAF-65] chore: add no-floating-promises rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ module.exports = {
     /* ecmaFeatures: {
       impliedStrict: true,
     }, */
+    project: [
+      './tsconfig.json',
+      './*/tsconfig.json',
+    ]
   },
   overrides: [
     {
@@ -50,5 +54,6 @@ module.exports = {
     'max-len': ['error', {
       code: 120,
     }],
+    '@typescript-eslint/no-floating-promises': 'error',
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devaltitude/eslint-config-alti-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "keywords": [
     "Altitude-sports",


### PR DESCRIPTION
**Problem statement**
When coding in typescript, missing an `await` or omit the handling of a `Promise`  returned by an `async` operation is a critical bug that introduces unexpected and really hard to debug behaviour.

**Solution**
This PR adds a TS lint rule to prevent these scenarios: https://typescript-eslint.io/rules/no-floating-promises/